### PR TITLE
Option to force a specific Stable Diffusion model

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1313,6 +1313,7 @@ namespace SallyBot
             var overrideSettings = new JObject
             {
                 { "filter_nsfw", true } // this doesn't work, if you can figure out why feel free to tell me :OMEGALUL:
+                // { "sd_model_checkpoint", "modelname.safetensors [hash]" } // Force a specific model to be used, overriding the selected model in the Stable Diffusion WebUI
             };
 
             var payload = new JObject


### PR DESCRIPTION
By default the image generation is handled by the currently selected Stable Diffusion checkpoint in the Web UI, which can cause undesired image generation if the wrong model is selected in the Web UI when SallyBot receives a request.

By specifying the checkpoint name such from the Stable Diffusion web UI this can be overridden in the API request by specifying "sd_model_checkpoint", and the checkpoint name.

![image](https://user-images.githubusercontent.com/5264946/232233652-e7ede6f5-5fd7-4c17-9268-71670082189a.png)

e.g: { "sd_model_checkpoint", "anything-v3-fp16-pruned.safetensors [d1facd9a2b]" }

This is probably only an issue if multiple image models are used and you're generating images with a different model than SallyBot should use.