### PR TITLE
Removing invalid key "filter_nsfw" from overrideSettings

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1323,7 +1323,7 @@ namespace SallyBot
                 { "height", 688 },
                 { "send_images", true },
                 { "sampler_name", "DDIM" },
-                { "filter_nsfw", true }
+                { "override_settings", overrideSettings },
             };
 
             // here are the json tags you can send to the stable diffusion image generator

--- a/Program.cs
+++ b/Program.cs
@@ -1312,7 +1312,6 @@ namespace SallyBot
 
             var overrideSettings = new JObject
             {
-                { "filter_nsfw", true } // this doesn't work, if you can figure out why feel free to tell me :OMEGALUL:
                 // { "sd_model_checkpoint", "modelname.safetensors [hash]" } // Force a specific model to be used, overriding the selected model in the Stable Diffusion WebUI
             };
 


### PR DESCRIPTION
filter_nsfw is invalid in the current version of stable-diffusion-webui.

This causes the below API error in stable-diffusion-webui:

API error: POST: http://127.0.0.1:7860/sdapi/v1/txt2img {'error': 'KeyError', 'detail': '', 'body': '', 'errors': "'filter_nsfw'"}