### PR TITLE
Update README.md to fix model name issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Arguments to be added here include:
 `--wbits 4` and `--groupsize 128` specify details about the model. If you know what you're doing you can remove whichever ones you don't need. `--groupsize 128` if you are using a non 128 groupsize model, or `--wbits 4` if you are not running a 4-bit quantized model, for instance. Most of the consumer running ones are 4bit quantized to run on normal amounts of vram, so you'll need this arg to run those models.
 
 Example of args:
-`--model TheBloke/WizardLM-7B-uncensored-GPTQ --loader exllama_hf --api --listen-port 7862 --wbits 4 --groupsize 128`
+`--model TheBloke_Llama-2-7B-Chat-GGML --loader exllama_hf --api --listen-port 7862 --wbits 4 --groupsize 128`
 
-![Image showing example of args](https://github.com/DeSinc/SallyBot/assets/36467674/eaa1caf1-0285-4c87-98f9-b45ba65d6df6)
+![Image showing example of args](https://github.com/DeSinc/SallyBot/assets/117759431/23ed964c-13c3-4984-ad74-0f5e1657c67e)
 
 If you'd like to modify the parameters for Oobabooga, it's this section here:
 ```c#

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Arguments to be added here include:
 Example of args:
 `--model TheBloke_Llama-2-7B-Chat-GGML --loader exllama_hf --api --listen-port 7862 --wbits 4 --groupsize 128`
 
-![Image showing example of args](https://github.com/DeSinc/SallyBot/assets/117759431/23ed964c-13c3-4984-ad74-0f5e1657c67e)
+![Image showing example of args](https://github.com/DeSinc/SallyBot/assets/117759431/935b57a9-3dde-402f-bd20-a2ea2bfe4aae)
 
 If you'd like to modify the parameters for Oobabooga, it's this section here:
 ```c#


### PR DESCRIPTION
Before, the model name in the example of args was just the UserName/ModelName which was not correct, as it is meant to be the file name (in oobabooga_windows\text-generation-webui\models).
This meant that the model would not be automatically loaded when launching the web ui.


Before: TheBloke/WizardLM-7B-uncensored-GPTQ --> UserName/ModelName (not correct)
After: TheBloke_Llama-2-7B-Chat-GGML --> The actual file name
^ I changed the model, not that it makes a difference, just couldn't be bothered to change mine tbh.

I also changed the photo, as that was wrong too.